### PR TITLE
style: 优化单列样式

### DIFF
--- a/index.scss
+++ b/index.scss
@@ -65,18 +65,18 @@ a {
 
 #colorList {
   overflow: hidden;
+  display: flex;
+  flex-wrap: wrap;
 }
 
 dl {
   line-height: 1.2;
   font-size: 0.75em;
   padding: 20px 0pt;
-  float: left;
   width: 470px;
   height: 125px;
   border-bottom: 1px dotted rgb(153, 153, 153);
-  margin-right: 20px;
-
+  margin: auto;
   &:hover {
     background-color: rgba(204, 204, 204, 0.1);
   }


### PR DESCRIPTION
单列展示item靠左,不够美观 居中比较好看
<img width="790" alt="image" src="https://user-images.githubusercontent.com/66287770/188535470-0e043eb2-af57-459d-8687-e077e9cd952e.png">
<img width="649" alt="image" src="https://user-images.githubusercontent.com/66287770/188535499-9675a8b9-4050-4897-b8e2-233c4b798070.png">
